### PR TITLE
Update page_listiing_buttons with user kwarg #6

### DIFF
--- a/wagtailmailchimp/wagtail_hooks.py
+++ b/wagtailmailchimp/wagtail_hooks.py
@@ -13,7 +13,7 @@ def urlconf_wagtail_mailchimp():
 
 
 @hooks.register('register_page_listing_buttons')
-def page_listing_buttons(page, page_perms, next_url=None):
+def page_listing_buttons(page, user, next_url=None):
     if hasattr(page, "is_mailchimp_integration") and hasattr(page, "audience_list_id"):
         if page.audience_list_id and page.show_page_listing_mailchimp_integration_button():
             url = reverse("mailchimp_integration_view", args=[page.pk, ])


### PR DESCRIPTION
Addresses #6 by replacing the `page_perms` argument with `user` per Wagtail 7.0 as documented in https://docs.wagtail.org/en/stable/releases/7.0.html#updates-to-button-rendering-hooks